### PR TITLE
Fix missing explicit conversion to int

### DIFF
--- a/ldoce5viewer/qtgui/ui/custom.py
+++ b/ldoce5viewer/qtgui/ui/custom.py
@@ -85,10 +85,10 @@ class LineEdit(QLineEdit):
         rect = self.rect()
         self._buttonFind.move(
                 framewidth + 3 - 1,
-                (rect.height() - ICONSIZE) / 2 - 1)
+                (rect.height() - ICONSIZE) // 2 - 1)
         self._buttonClear.move(
                 rect.width() - framewidth - 3 - ICONSIZE - 1,
-                (rect.height() - ICONSIZE) / 2 - 1)
+                (rect.height() - ICONSIZE) // 2 - 1)
 
     def __onTextChanged(self, text):
         self._buttonClear.setVisible(bool(text))
@@ -149,7 +149,7 @@ class HtmlListWidget(QListWidget):
                 doc = self._doc
                 doc.setDefaultFont(option.font)
                 doc.setHtml('<body>MNmn012<span class="p">012</span></body>')
-                height = doc.size().height() + self.MARGIN_V * 2
+                height = int(doc.size().height() + self.MARGIN_V * 2)
                 s = self._item_size = QSize(0, height)
             return s
 


### PR DESCRIPTION
In some places, a function expects an int, but is incorrectly given a float.
Here are the error messages I've encountered:
```sh
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/ldoce5viewer/qtgui/ui/custom.py", line 86, in resizeEvent
    self._buttonFind.move(
TypeError: arguments did not match any overloaded call:
  move(self, QPoint): argument 1 has unexpected type 'int'
  move(self, int, int): argument 2 has unexpected type 'float'
```
and after fixing that, you'd receive this:
```sh
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/ldoce5viewer/qtgui/ui/custom.py", line 153, in sizeHint
    s = self._item_size = QSize(0, height)
TypeError: arguments did not match any overloaded call:
  QSize(): too many arguments
  QSize(int, int): argument 2 has unexpected type 'float'
  QSize(QSize): argument 1 has unexpected type 'int'
```
This PR tries to fix both of these issues. 