### PR TITLE
explicitly use Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PKG := ldoce5viewer
-PYTHON := python
+PYTHON := python3
 
 build: precompile
 	$(PYTHON) ./setup.py build

--- a/ldoce5viewer.py
+++ b/ldoce5viewer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/ldoce5viewer/__init__.py
+++ b/ldoce5viewer/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals, print_function

--- a/ldoce5viewer/qtgui/resources/icons/icongen.py
+++ b/ldoce5viewer/qtgui/resources/icons/icongen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
 

--- a/ldoce5viewer/utils/compat.py
+++ b/ldoce5viewer/utils/compat.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals, print_function

--- a/scripts/ldoce5viewer
+++ b/scripts/ldoce5viewer
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import subprocess
 from distutils.core import setup


### PR DESCRIPTION
This PR tells the system to explicitely use Python 3. Otherwise some distros still use Python 2 (Debian 10 e.g.), and things won't work.